### PR TITLE
Environment shouldn't be required (allow empty string)

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -32,9 +32,9 @@ type Commit struct {
 type DeployRequest struct {
 	Service      string    `validate:"required" json:"service"`
 	Deployer     Deployer  `validate:"required" json:"deployer"`
-	Environment  string    `validate:"required" json:"environment"`
 	DeployedAt   time.Time `validate:"required" json:"deployed_at"`
 	Description  string    `validate:"required" json:"description"`
+	Environment  string    `json:"environment"`
 	DeployURL    string    `json:"deploy_url"`
 	DeployNumber string    `json:"deploy_number"`
 	Commit       Commit    `json:"commit"`

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -89,8 +89,7 @@ func TestDeploy(t *testing.T) {
 
 	t.Run("Returns an error for an invalid request", func(t *testing.T) {
 		deployRequest := DeployRequest{
-			Service:     "my_service",
-			Description: "Deployed service",
+			Service: "my_service",
 			Deployer: Deployer{
 				Email: "deployer@xyz.com",
 			},
@@ -108,7 +107,7 @@ func TestDeploy(t *testing.T) {
 		err := client.Deploy(deployRequest, "uuid")
 		assert.EqualError(t,
 			err,
-			"Key: 'DeployRequest.Environment' Error:Field validation for 'Environment' failed on the 'required' tag",
+			"Key: 'DeployRequest.Description' Error:Field validation for 'Description' failed on the 'required' tag",
 		)
 	})
 }


### PR DESCRIPTION
Opslevel accepts an empty environment `environment: ""` in the request body 