### PR TITLE
Add support for payload checks integration

### DIFF
--- a/check.go
+++ b/check.go
@@ -16,7 +16,7 @@ type CheckRequest struct {
 	Message string `json:"message"`
 }
 
-// Check sends a CheckRequest to the OpsLevel deploy integration at integrationID
+// Check sends a CheckRequest to the OpsLevel check integration at integrationID
 func (c *Client) Check(req CheckRequest, integrationID string) error {
 	v := validator.New()
 	if err := v.Struct(req); err != nil {

--- a/payload.go
+++ b/payload.go
@@ -1,0 +1,35 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/go-playground/validator.v9"
+)
+
+// PayloadRequest represents a structured request to the OpsLevel payload webhook endpoint
+type PayloadRequest struct {
+	Service string      `validate:"required" json:"service"`
+	Check   string      `validate:"required" json:"check"`
+	Data    interface{} `validate:"required" json:"data"`
+}
+
+// Payload sends a PayloadRequest to the OpsLevel payload check integration at integrationID
+func (c *Client) Payload(req PayloadRequest, integrationID string) error {
+	v := validator.New()
+	if err := v.Struct(req); err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Result string `json:"result"`
+	}
+
+	fullURL := fmt.Sprintf("/integrations/payload/%s", integrationID)
+	return c.do("POST", fullURL, bytes.NewReader(b), &resp)
+}

--- a/payload_test.go
+++ b/payload_test.go
@@ -1,0 +1,137 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type myData struct {
+	High   int `validate:"required" json:"high"`
+	Medium int `validate:"required" json:"medium"`
+	Low    int `validate:"required" json:"low"`
+}
+
+func TestPayload(t *testing.T) {
+	t.Run("Doesn't return an error for a valid request", func(t *testing.T) {
+
+		payloadRequest := PayloadRequest{
+			Service: "my_service",
+			Check:   "my_check",
+			Data: myData{
+				High:   1,
+				Medium: 2,
+				Low:    3,
+			},
+		}
+
+		body := `
+		{
+			"result": "ok"
+		}
+		`
+		client, testServer := setupTest(202, body)
+		defer func() { testServer.Close() }()
+
+		err := client.Payload(payloadRequest, "uuid")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Returns a Bad Request error on a 422", func(t *testing.T) {
+		payloadRequest := PayloadRequest{
+			Service: "my_service",
+			Check:   "my_check",
+			Data: myData{
+				High:   1,
+				Medium: 2,
+				Low:    3,
+			},
+		}
+
+		body := `
+		{
+			"errors":[
+				{"status":400,"title":"Check Error","detail":"param is missing or the value is empty: data"}
+			]
+		}
+		`
+		client, testServer := setupTest(400, body)
+		defer func() { testServer.Close() }()
+
+		err := client.Payload(payloadRequest, "uuid")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "status 400")
+	})
+
+	t.Run("Returns a Something Went Wrong error on all other status codes", func(t *testing.T) {
+		payloadRequest := PayloadRequest{
+			Service: "my_service",
+			Check:   "my_check",
+			Data: myData{
+				High:   1,
+				Medium: 2,
+				Low:    3,
+			},
+		}
+
+		body := `
+		{
+			"errors":[
+				{"status":503,"title":"Service Unavailable"}
+			]
+		}
+		`
+		client, testServer := setupTest(503, body)
+		defer func() { testServer.Close() }()
+
+		err := client.Payload(payloadRequest, "uuid")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "status 503")
+	})
+
+	t.Run("Returns an error for an invalid request", func(t *testing.T) {
+		payloadRequest := PayloadRequest{
+			Service: "my_service",
+			Check:   "my_check",
+		}
+
+		body := `
+		{
+			"result": "ok"
+		}
+		`
+		client, testServer := setupTest(202, body)
+		defer func() { testServer.Close() }()
+
+		err := client.Payload(payloadRequest, "uuid")
+		assert.EqualError(t,
+			err,
+			"Key: 'PayloadRequest.Data' Error:Field validation for 'Data' failed on the 'required' tag",
+		)
+	})
+
+	t.Run("Returns an error for an invalid request on nested Data interface", func(t *testing.T) {
+		payloadRequest := PayloadRequest{
+			Service: "my_service",
+			Check:   "my_check",
+			Data: myData{
+				Medium: 2,
+				Low:    3,
+			},
+		}
+
+		body := `
+		{
+			"result": "ok"
+		}
+		`
+		client, testServer := setupTest(202, body)
+		defer func() { testServer.Close() }()
+
+		err := client.Payload(payloadRequest, "uuid")
+		assert.EqualError(t,
+			err,
+			"Key: 'PayloadRequest.Data.High' Error:Field validation for 'High' failed on the 'required' tag",
+		)
+	})
+}


### PR DESCRIPTION
This PR adds support for OpsLevel payload checks. Here's what a sample request might look like via curl:
```
curl -X POST https://app.opslevel.com/integrations/payload/<ID> \
-H 'content-type: application/json' \
-d '{
  "service": "serviceAlias",
  "check": "checkReferenceId",
  "data": {
    "_comment": "YOUR DATA HERE"
  }
}'
```