### PR TITLE
Add dedup_id to deployment request

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -38,6 +38,7 @@ type DeployRequest struct {
 	DeployURL    string    `json:"deploy_url"`
 	DeployNumber string    `json:"deploy_number"`
 	Commit       Commit    `json:"commit"`
+	DedupID      string    `json:"dedup_id"`
 }
 
 // Deploy sends a DeployRequest to the OpsLevel deploy integration at integrationID


### PR DESCRIPTION
They just added support for a new field to make the deployments integration idempotent. This gives us the luxury of having to provide "at-least once" vs "exactly once" delivery semantics and simplifies the case where we might have more than one actor reporting deployments (when we're deploying treb or the k2-opslevel controller for instance).

https://www.opslevel.com/docs/insights/deploys/#tracking-deploys